### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
 name: Node.js CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Spencer14420/SPEmailHandler/security/code-scanning/2](https://github.com/Spencer14420/SPEmailHandler/security/code-scanning/2)

To fix the problem, we should add a `permissions` block to the workflow, specifying the least privilege required. Since the workflow only checks out code, installs dependencies, builds, and runs tests, it does not require write access to repository contents or other resources. The minimal required permission is `contents: read`. This block can be added at the root level (recommended for single-job workflows) or at the job level. In this case, adding it at the root level (just after the `name:` and before `on:`) will ensure all jobs inherit these minimal permissions unless overridden.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
